### PR TITLE
Specify etcd command flags as we do in the dockerfile

### DIFF
--- a/conf/nsolid.cloud.yml
+++ b/conf/nsolid.cloud.yml
@@ -45,6 +45,14 @@ items:
           - image: nodesource/nsolid-registry
             name: registry
             args:
+              - "-name"
+              - "etcd0"
+              - "-listen-client-urls"
+              - "http://0.0.0.0:4001,http://0.0.0.0:2379"
+              - "-advertise-client-urls"
+              - "http://0.0.0.0:4001,http://0.0.0.0:2379"
+              - "-initial-cluster-state"
+              - "new"
               - "--data-dir"
               - /var/lib/nsolid/registry
             ports:

--- a/conf/nsolid.quickstart.yml
+++ b/conf/nsolid.quickstart.yml
@@ -18,6 +18,17 @@ items:
           containers:
           - image: nodesource/nsolid-registry
             name: registry
+            args:
+              - "-name"
+              - "etcd0"
+              - "-listen-client-urls"
+              - "http://0.0.0.0:4001,http://0.0.0.0:2379"
+              - "-advertise-client-urls"
+              - "http://0.0.0.0:4001,http://0.0.0.0:2379"
+              - "-initial-cluster-state"
+              - "new"
+              - "--data-dir"
+              - /var/lib/nsolid/registry
             ports:
             - containerPort: 2380
               name: serverport


### PR DESCRIPTION
Reported by a customer and then duplicated in my k8s clusters.  etcd was listening on localhost rather than 0.0.0.0.

What was happening is that in the cloud configuration, we were specifying `args` which was over-riding the CMD defined in the Dockerfile https://github.com/nodesource/docker-nsolid/blob/master/nsolid-registry/Dockerfile#L4.

This PR specifies the necessary etcd CMD args within the Deployment objects.