### PR TITLE
Nw/security open shift

### DIFF
--- a/conf/nginx.Dockerfile
+++ b/conf/nginx.Dockerfile
@@ -1,8 +1,10 @@
 FROM nginx:stable
 
-RUN touch /var/run/nginx.pid && \
-    chown -R www-data:www-data /var/run/nginx.pid \
-&&  chown -R www-data:www-data /var/cache/nginx
+RUN touch /var/run/nginx.pid \
+ && chown -R www-data:root /var/run/nginx.pid \
+ && chmod -R 0770 /var/run/nginx.pid \
+ && chown -R www-data:root /var/cache/nginx \
+ && chmod -R 0770 /var/cache/nginx;
 
 USER www-data
 

--- a/conf/nginx.Dockerfile
+++ b/conf/nginx.Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:stable
+
+RUN touch /var/run/nginx.pid && \
+    chown -R www-data:www-data /var/run/nginx.pid \
+&&  chown -R www-data:www-data /var/cache/nginx
+
+USER www-data
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -1,4 +1,3 @@
-user www-data;
 pid /run/nginx.pid;
 error_log /dev/stdout;
 worker_processes  1;
@@ -32,7 +31,7 @@ http {
 
   # Redirect all traffic to SSL
   server {
-    listen 80;
+    listen 10080;
     return 301 https://$host$request_uri;
   }
 

--- a/conf/nginx/nsolid-nginx.conf
+++ b/conf/nginx/nsolid-nginx.conf
@@ -3,14 +3,14 @@ upstream console {
 }
 
 server {
-  listen 80 default_server;
-  listen [::]:80 default_server;
+  listen 10080 default_server;
+  listen [::]:10080 default_server;
   server_name nsolid;
   return 301 https://$host$request_uri;
 }
 
 server {
-  listen 443 ssl;
+  listen 10443 ssl;
   server_name nsolid
   ssl on;
   ssl_certificate /etc/nginx/ssl/nsolid-nginx.crt;

--- a/conf/nsolid.cloud.yml
+++ b/conf/nsolid.cloud.yml
@@ -94,13 +94,13 @@ items:
             app: nginx-secure-proxy
         spec:
           containers:
-          - image: nginx
+          - image: nodesource/nsolid-nginx:stable
             imagePullPolicy: Always
             name: nginx-secure-proxy
             ports:
-            - containerPort: 80
+            - containerPort: 10080
               protocol: TCP
-            - containerPort: 443
+            - containerPort: 10443
               protocol: TCP
             - containerPort: 8080
               protocol: TCP

--- a/conf/nsolid.quickstart.yml
+++ b/conf/nsolid.quickstart.yml
@@ -72,13 +72,13 @@ items:
             app: nginx-secure-proxy
         spec:
           containers:
-          - image: nginx
+          - image: nodesource/nsolid-nginx:stable
             imagePullPolicy: Always
             name: nginx-secure-proxy
             ports:
-            - containerPort: 80
+            - containerPort: 10080
               protocol: TCP
-            - containerPort: 443
+            - containerPort: 10443
               protocol: TCP
             - containerPort: 8080
               protocol: TCP

--- a/conf/nsolid.services.yml
+++ b/conf/nsolid.services.yml
@@ -49,10 +49,10 @@ items:
         - name: http
           protocol: TCP
           port: 80
-          targetPort: 80
+          targetPort: 10080
         - name: https
           protocol: TCP
           port: 443
-          targetPort: 443
+          targetPort: 10443
       selector:
         app: nginx-secure-proxy


### PR DESCRIPTION
* Creates a custom nginx image published at [nodesource/nsolid-nginx:stable](https://hub.docker.com/r/nodesource/nsolid-nginx/)
* Reconfigured port mapping to use non-priv ports
* Updated `nginx.conf` to not explicitly set user as it throws a warning in non-root mode.