### PR TITLE
Updating Azure instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,7 @@ aws ec2 create-volume --availability-zone eu-west-1a --size 10 --volume-type gp2
 
 ##### On Azure
 
-We need to deploy a default [`StorageClass`](https://kubernetes.io/docs/user-guide/persistent-volumes/#azure-disk) object that will automatically provision new `PersistentVolume` instances (backed by an Azure data disk) for all `PersistentVolumeClaim` objects that are bound to pods (e.g. the `nsolid.storage` pod).
-
-```shell
-kubectl create -f https://raw.githubusercontent.com/Azure/acs-engine/master/parts/kubernetesmasteraddons-default-storage-class.yaml 
-```
-
-> Once the Azure Container Service is updated to run Kubernetes `v1.5.3` by default, the above command won't even be neccessary.
+There's no need to explicitly create a persistent disk, since the Azure Container Service provides a default `StorageClass`, which will dynamically create them as needed (e.g. when a `Pod` includes a `PersistentVolumeClaim`).
 
 #### Configure Kubernetes to utilize the newly created persistent volumes
 
@@ -253,7 +247,7 @@ kubectl create -f conf/nsolid.persistent.aws.yml
 
 ##### Azure
 
-There's no need to explicitly create a `PersistentVolume` object, since the `StorageClass` that was previously created will automatically provision them as needed.
+There's no need to explicitly create a `PersistentVolume` object, since they will be dynamically provisioned by the default `StorageClass`.
 
 #### Deploy N|Solid components
 


### PR DESCRIPTION
Updating the setup instructions for Azure to indicate the fact that the default `StorageClass` object no longer needs to be explicitly provisioned into the cluster.