### PR TITLE
Adding Azure Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ kubectl create -f sample-app.deployment.yml
 **NOTE:** container image in `sample-app.deployment.yml` assumes `sample-app:v1` docker image. This will work if your using `minikube` and ran `eval $(minikube docker-env)`.
 
 If you are working in a cloud environment, you will need to push the sample-app to a public Docker registry
-like [Dockerhub](https://dockerhub.com) or [Quay.io](https://quay.io), and update the sample-app Deployment file.
+like [Dockerhub](https://dockerhub.com), [Quay.io](https://quay.io) or the [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/), and update the sample-app Deployment file.
 
 
 <a name="a6"/>


### PR DESCRIPTION
This PR simply adds a mention to the Azure Container Registry, in order to provide visibility of it for readers who are deploying to Azure.