### PR TITLE
Instructions for Kubernetes on the IBM Cloud.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This repository is for deploying [N|Solid](https://nodesource.com/products/nsoli
 * [kubernetes on aws](http://kubernetes.io/docs/getting-started-guides/aws/) - Amazon Web Services
 * [kubernetes on GCE](http://kubernetes.io/docs/getting-started-guides/gce/) - Google Compute Engine
 * [kubernetes on ACS](http://kubernetes.io/docs/getting-started-guides/azure/) - Microsoft Azure Container Service
+* [kubernetes on Bluemix](./docs/install/bluemix-setup.md) - IBM Cloud Container Service
 
 <a name="a1-1"/>
 
@@ -62,7 +63,7 @@ kubectl apply -f conf/nsolid.quickstart.yml
 
 ### Cloud
 
-If deployed to a cloud (AWS, Azure, GCP) please make sure to make the necessary adjustments to `conf/nsolid.cloud.yml` 
+If deployed to a cloud (AWS, Azure, GCP, Bluemix) please make sure to make the necessary adjustments to `conf/nsolid.cloud.yml`
 
 ```bash
 kubectl apply -f conf/nsolid.cloud.yml
@@ -72,11 +73,12 @@ kubectl apply -f conf/nsolid.cloud.yml
 
 ## Quickstart
 
-Make sure your `kubectl` is pointing to your active cluster.
-
 ```bash
 ./install
 ```
+Notes:
+1. Make sure your `kubectl` is pointing to your active cluster.
+1. If your cluster is a Bluemix _Lite_ cluster, [make this adjustment](./docs/install/bluemix-lite.md) to conf/nsolid.services.yml before running ./install.
 
 This command will install the N|Solid Console, N|Solid Storage, and a secure HTTPS proxy to the `nsolid` namespace.
 
@@ -112,7 +114,7 @@ or
 kubectl get svc nginx-secure-proxy --namespace=nsolid
 ```
 
-Open `EXTERNAL-IP`
+Open `EXTERNAL-IP`.  `If using Bluemix _Lite_ cluster, get EXTERNAL-IP` [this way](./docs/misc/bluemix-external-ip.md).
 
 **NOTE:** You will need to ignore the security warning on the self signed certificate to proceed.
 
@@ -139,10 +141,17 @@ kubectl create -f sample-app.service.yml
 kubectl create -f sample-app.deployment.yml
 ```
 
-**NOTE:** container image in `sample-app.deployment.yml` assumes `sample-app:v1` docker image. This will work if your using `minikube` and ran `eval $(minikube docker-env)`.
+**NOTE:** the container image in `sample-app.deployment.yml` must be set to match your docker image name. E.g. if you are using `minikube` and ran `eval $(minikube docker-env)`, set the image to:
+
+```bash
+    spec:
+      containers:
+        - name: sample-app
+          image: sample-app:v1
+```
 
 If you are working in a cloud environment, you will need to push the sample-app to a public Docker registry
-like [Docker Hub](https://hub.docker.com/), [Quay.io](https://quay.io) or the [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/), and update the sample-app Deployment file.
+like [Docker Hub](https://hub.docker.com/), [Quay.io](https://quay.io), the [Azure Container Registry](https://azure.microsoft.com/en-us/services/container-registry/), or the [IBM Bluemix Container Registry](https://console.bluemix.net/docs/services/Registry/registry_images_.html#registry_images_), and update the sample-app Deployment file.
 
 
 <a name="a6"/>
@@ -199,6 +208,8 @@ kubectl create configmap nginx-config --from-file=conf/nginx --namespace=nsolid
 kubectl create -f conf/nsolid.services.yml
 ```
 
+Note: If your cluster is a Bluemix _Lite_ cluster, [make this adjustment](./docs/install/bluemix-lite.md) to conf/nsolid.services.yml before running kubectl create.
+
 #### Create persistent disks
 
 N|Solid components require persistent storage.  Kubernetes does not (yet!)
@@ -233,6 +244,11 @@ aws ec2 create-volume --availability-zone eu-west-1a --size 10 --volume-type gp2
 
 There's no need to explicitly create a persistent disk, since the Azure Container Service provides a default `StorageClass`, which will dynamically create them as needed (e.g. when a `Pod` includes a `PersistentVolumeClaim`).
 
+##### On Bluemix
+
+There's no need to explicitly create a persistent disk, since the Bluemix Container Service provides a default `StorageClass`, which will dynamically create them as needed (e.g. when a `Pod` includes a `PersistentVolumeClaim`).
+
+
 #### Configure Kubernetes to utilize the newly created persistent volumes
 
 ##### GCE
@@ -248,6 +264,11 @@ kubectl create -f conf/nsolid.persistent.aws.yml
 ##### Azure
 
 There's no need to explicitly create a `PersistentVolume` object, since they will be dynamically provisioned by the default `StorageClass`.
+
+##### Bluemix
+
+There's no need to explicitly create a `PersistentVolume` object, since they will be dynamically provisioned by the default `StorageClass`.
+
 
 #### Deploy N|Solid components
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository is for deploying [N|Solid](https://nodesource.com/products/nsoli
     - [GCE persistent disks](#a13)
     - [AWS persistent disks](#a14)
     - [Azure persistent disks](#a29)
+    - [Bluemix persistent disks](#a30)
 - [Debugging / Troubleshooting](#a15)
     - [Configuring Apps for N|Solid with kubernetes](#a16)
         - [Building an N|Solid app](#a17)
@@ -243,6 +244,8 @@ aws ec2 create-volume --availability-zone eu-west-1a --size 10 --volume-type gp2
 ##### On Azure
 
 There's no need to explicitly create a persistent disk, since the Azure Container Service provides a default `StorageClass`, which will dynamically create them as needed (e.g. when a `Pod` includes a `PersistentVolumeClaim`).
+
+<a name="a30"/>
 
 ##### On Bluemix
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ or
 kubectl get svc nginx-secure-proxy --namespace=nsolid
 ```
 
-Open `EXTERNAL-IP`.  `If using Bluemix _Lite_ cluster, get EXTERNAL-IP` [this way](./docs/misc/bluemix-external-ip.md).
+Open `EXTERNAL-IP`.  If using Bluemix _Lite_ cluster, get EXTERNAL-IP [this way](./docs/misc/bluemix-external-ip.md).
 
 **NOTE:** You will need to ignore the security warning on the self signed certificate to proceed.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository is for deploying [N|Solid](https://nodesource.com/products/nsoli
     - [Azure persistent disks](#a29)
 - [Debugging / Troubleshooting](#a15)
     - [Configuring Apps for N|Solid with kubernetes](#a16)
-        - [Buiding an N|Solid app](#a17)
+        - [Building an N|Solid app](#a17)
             - [Docker](#a18)
             - [Kubernetes](#a19)
         - [Accessing your App](#a20)

--- a/README.md
+++ b/README.md
@@ -334,7 +334,8 @@ A comma seperate list of tags that can be used to filter processes in the N|Soli
 kubectl get svc {service-name}
 ```
 
-The `EXTERNAL-IP` will access the application.
+The `EXTERNAL-IP` will access the application.  
+Open `EXTERNAL-IP`.  If using Bluemix _Lite_ cluster, get EXTERNAL-IP [this way](./docs/misc/bluemix-external-ip.md).
 
 
 <a name="a21"/>

--- a/docs/install/bluemix-lite.md
+++ b/docs/install/bluemix-lite.md
@@ -1,0 +1,17 @@
+## IBM Cloud Container Service
+
+### Change service type before deploying N|Solid. 
+
+If you are using the Lite (free) plan, you have a single VM Kubernetes cluster. This environment is limited to the NodePort service type. So before you deploy to a Lite Kubernetes cluster, make the following change to your conf/nsolid.services.yml file: 
+
+```bash
+From
+
+    spec:
+      type: LoadBalancer 
+
+To
+
+    spec:
+      type: NodePort
+```

--- a/docs/install/bluemix-setup.md
+++ b/docs/install/bluemix-setup.md
@@ -1,0 +1,30 @@
+## IBM Cloud Container Service
+
+### Setup 
+
+#### Getting Started 
+
+Register and create a Lite Kubernetes cluster using the 
+[IBM Cloud Container Service](https://www.ibm.com/cloud-computing/bluemix/containers).
+
+#### Install IBM Cloud Tools 
+
+Linux/OSX install: 
+```bash
+curl -sL https://ibm.biz/idt-installer | bash
+```
+
+Windows install (and general information):
+
+See: [https://github.com/IBM-Bluemix/ibm-cloud-developer-tools](https://github.com/IBM-Bluemix/ibm-cloud-developer-tools)
+
+#### Address Kubernetes Cluster 
+
+1. login 
+```bash
+bx login -a api.ng.bluemix.net
+```
+1. export KUBECONFIG
+```bash
+bx cs cluster-config mycluster
+```

--- a/docs/misc/bluemix-external-ip.md
+++ b/docs/misc/bluemix-external-ip.md
@@ -1,0 +1,31 @@
+## IBM Cloud Container Service
+
+### Get external IP and service port 
+
+Linux/OSX: 
+```bash
+printf "\nhttps://$(bx cs workers mycluster | awk '{ split($2,t,"""Public"""); printf """%s+""", t[1] }' | awk '{ split($1,ip,"""+"""); print ip[3] }'):$(kubectl get svc nginx-secure-proxy --namespace=nsolid --output='jsonpath={.spec.ports[1].nodePort}')\n"
+```
+
+Windows: 
+
+1. get Public IP
+```bash
+bx cs workers mycluster
+```
+The preceding bx command displays the public IP like this example: 
+```bash
+ID                                                 Public IP         Private IP      Machine Type   State    Status   Version
+kube-hou02-pa2ccba8cbbcd243b39dd79fc0a6ad24bb-w1   184.172.236.206   10.76.114.209   free           normal   Ready    1.5.6_921
+```
+
+1. get service port 
+```bash
+kubectl get svc nginx-secure-proxy --namespace=nsolid 
+``` 
+The preceding kubectl command displays the service ports like this example: 
+```bash
+NAME                 CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
+nginx-secure-proxy   10.10.10.7   <pending>     80:32144/TCP,443:30238/TCP   8m
+```
+The first node port (32144) is for http. The second (30238) is for https.

--- a/docs/misc/bluemix-external-ip.md
+++ b/docs/misc/bluemix-external-ip.md
@@ -6,6 +6,7 @@ Linux/OSX:
 ```bash
 printf "\nhttps://$(bx cs workers mycluster | awk '{ split($2,t,"""Public"""); printf """%s+""", t[1] }' | awk '{ split($1,ip,"""+"""); print ip[3] }'):$(kubectl get svc nginx-secure-proxy --namespace=nsolid --output='jsonpath={.spec.ports[1].nodePort}')\n"
 ```
+Note: if using this command for an application,  replace "nginx-secure-proxy" in the command text with the {service-name} of the application.
 
 Windows: 
 
@@ -23,6 +24,8 @@ kube-hou02-pa2ccba8cbbcd243b39dd79fc0a6ad24bb-w1   184.172.236.206   10.76.114.2
 ```bash
 kubectl get svc nginx-secure-proxy --namespace=nsolid 
 ``` 
+Note: if using this command for an application,  replace "nginx-secure-proxy" in the command text with the {service-name} of the application.
+
 The preceding kubectl command displays the service ports like this example: 
 ```bash
 NAME                 CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE


### PR DESCRIPTION
I followed the pattern already established and added relevant info for the IBM Cloud.  I added a small number of detail files in the docs/install and docs/misc directories.  

I also made an update to installing the sample-app.  The original documentation stated the image name in sample-app-deployment.yaml was set to sample-app:v1.  But that's not accurate.  The deployment yaml actually contains only a placedholder - e.g. {image}:{tag}, so I added a short paragraph directing the user to update that file before deploying to Kubernetes. 